### PR TITLE
Fix file name reference.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,6 @@ setup(
     license='LICENSE',
     description=('A Python library to '
                  'interface with a Cuckoo instance'),
-    long_description=read('README.TXT'),
+    long_description=read('README.txt'),
     install_requires=['requests[security]'],
 )


### PR DESCRIPTION
Some filesystems are case-sensitive. This allows the package to be built and installed when README.TXT and README.txt are two different files.